### PR TITLE
feat: add GTM handler and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install nuxt-google-optimize --save
     // experimentsDir: '~/experiments',
     // maxAge: 60 * 60 * 24 * 7 // 1 Week
     // pushPlugin: true,
-    // eventHandler: 'ga', // 'ga' = Google Analytics integration || 'gtm' = @nuxtjs/gtm-module integration || 'dataLayer' = GTM integration
+    // eventHandler: 'ga', // 'ga' (default) = Google Analytics integration || 'gtm' = @nuxtjs/gtm-module integration || 'dataLayer' = GTM integration
     // dataLayer: 'dataLayer', // eventHandler option has to be 'dataLayer' when implementing custom GTM dataLayer
     // excludeBots: true,
     // botExpression: /(bot|spider|crawler)/i

--- a/README.md
+++ b/README.md
@@ -41,16 +41,70 @@ npm install nuxt-google-optimize --save
 
   // Optional options
   googleOptimize: {
-    // experimentsDir: '~/experiments',
-    // maxAge: 60 * 60 * 24 * 7 // 1 Week
-    // pushPlugin: true,
-    // eventHandler: 'ga', // 'ga' (default) = Google Analytics integration || 'gtm' = @nuxtjs/gtm-module integration || 'dataLayer' = GTM integration
-    // dataLayer: 'dataLayer', // eventHandler option has to be 'dataLayer' when implementing custom GTM dataLayer
-    // excludeBots: true,
-    // botExpression: /(bot|spider|crawler)/i
+    /* module options */
   }
 }
 ```
+
+## Options
+
+### `experimentsDir`
+
+- Type: `String`
+- Default: `'~/experiments'`
+
+Provide path where experiments are located.
+
+### `maxAge`
+
+- Type: `Number`
+- Default: `60 * 60 * 24 * 7`
+
+Provides default max age for user to test.
+
+### `pushPlugin`
+
+- Type: `Boolean`
+- Default: `true`
+
+### `eventHandler`
+
+- Type: `Function`
+- Default:
+```js
+(experiment, context) => {
+  const exp =
+    experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
+  const { ga } = window
+  if (!ga) return
+  ga('set', 'exp', exp)
+}
+```
+
+Provide custom event handler to send experiment details.
+
+Usage example:
+```js
+googleOptimize: {
+  eventHandler: (experiment, context) => {
+    const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
+    const { ga } = window
+    if (!ga) return
+    ga('set', 'exp', exp)
+  }
+}
+```
+
+### `excludeBots`
+
+- Type: `Boolean`
+- Default: `true`
+
+### `botExpression`
+
+- Type: `RegExp`
+- Default: `/(bot|spider|crawler)/i`
+
 
 ## Usage
 
@@ -226,7 +280,26 @@ import './styles.scss'
 
 ## Usage with GTM
 
-- Set `options.eventHandler` to 'gtm' or 'dataLayer' depending which integration style you use for Tag Manager.
+- Set `options.eventHandler`:
+```js
+// GTM module
+{
+  eventHandler: (experiment, { $gtm }) => {
+    const exp = `${experiment.experimentID}.${experiment.$variantIndexes.join( '-' )}`
+    $gtm.push({ exp })
+  }
+}
+
+// Default datalayer
+{
+  eventHandler: (experiment, { $gtm }) => {
+    const exp = `${experiment.experimentID}.${experiment.$variantIndexes.join( '-' )}`
+    const { dataLayer } = window
+    if (!dataLayer) return
+    dataLayer.push({ exp })
+  }
+}
+```
 - Edit your "Page view (Google Analytics)" -tag in [Google Tag Manager](https://tagmanager.google.com/#/home)
   - Add new "Fields to Set":
     - Field Name: exp
@@ -234,6 +307,7 @@ import './styles.scss'
 - Add new Data Layer Variable called "googleOptimizeExp" as defined above.
   - Variable type: Data Layer Variable
   - Data Layer Variable Name: exp
+
 
 [Source for this setup lossleader's answer in StackOverflow](https://stackoverflow.com/a/53253769/871677)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm install nuxt-google-optimize --save
     // experimentsDir: '~/experiments',
     // maxAge: 60 * 60 * 24 * 7 // 1 Week
     // pushPlugin: true,
+    // eventHandler: 'ga', // 'ga' = Google Analytics integration || 'gtm' = @nuxtjs/gtm-module integration || 'dataLayer' = GTM integration
+    // dataLayer: 'dataLayer', // eventHandler option has to be 'dataLayer' when implementing custom GTM dataLayer
     // excludeBots: true,
     // botExpression: /(bot|spider|crawler)/i
   }
@@ -221,6 +223,22 @@ import './styles.scss'
   background-color: blue;
 }
 ```
+
+## Usage with GTM
+
+- Set `options.eventHandler` to 'gtm' or 'dataLayer' depending which integration style you use for Tag Manager.
+- Edit your "Page view (Google Analytics)" -tag in [Google Tag Manager](https://tagmanager.google.com/#/home)
+  - Add new "Fields to Set":
+    - Field Name: exp
+    - Value: {{googleOptimizeExp}}
+- Add new Data Layer Variable called "googleOptimizeExp" as defined above.
+  - Variable type: Data Layer Variable
+  - Data Layer Variable Name: exp
+
+[Source for this setup lossleader's answer in StackOverflow](https://stackoverflow.com/a/53253769/871677)
+
+Now this module pushes experiment id and variable number to Google Analytics via Google Tag Manager.
+experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
 
 ## Development
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,8 +7,12 @@ module.exports = async function module (moduleOptions) {
       experimentsDir: '~/experiments',
       maxAge: 60 * 60 * 24 * 7, // 1 Week
       plugins: [],
-      eventHandler: 'ga',
-      dataLayer: 'dataLayer',
+      eventHandler: (experiment, context) => {
+        const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
+        const { ga } = window
+        if (!ga) return
+        ga('set', 'exp', exp)
+      },
       excludeBots: true,
       botExpression: /(bot|spider|crawler)/i
     },

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,6 +7,8 @@ module.exports = async function module (moduleOptions) {
       experimentsDir: '~/experiments',
       maxAge: 60 * 60 * 24 * 7, // 1 Week
       plugins: [],
+      eventHandler: 'ga',
+      dataLayer: 'dataLayer',
       excludeBots: true,
       botExpression: /(bot|spider|crawler)/i
     },

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,31 +120,26 @@ function setCookie(ctx, name, value, maxAge = <%= options.maxAge %>) {
 }
 
 // https://developers.google.com/optimize/devguides/experiments
-function googleOptimize(ctx) {
-  const { experiment } = ctx
-  if (process.server || !experiment || !experiment.experimentID) {
-    return
-  }
+function googleOptimize({ experiment, $gtm }) {
+  if (process.server || !experiment || !experiment.experimentID) return
+
+  const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
 
   // Choose method to track experiment and variant
-  <% if (options.eventHandler === 'ga') { %>
-    // Use Google Analytics integration
-    // https://developers.google.com/optimize/devguides/experiments
-    const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
-    if (!window.ga) return
-    window.ga('set', 'exp', exp)
-  <% } else if (options.eventHandler === 'gtm') { %>
+  <% if (options.eventHandler === 'gtm') { %>
     // Use @nuxtjs/gtm-module
-    if (!ctx.$gtm) return
-    ctx.$gtm.push({
-      exp: exp
-    })
-  <% } else if (options.eventHandler === 'dataLayer') { %>
+    if (!$gtm) return
+  $gtm.push({ exp })
+    <% } else if (options.eventHandler === 'dataLayer') { %>
     // Use other tag manager integration
-    if (!window[options.dataLayer]) return
-    window[options.dataLayer].push({
-      exp: exp
-    })
+    const gtmDataLayer = window[<%= options.dataLayer %>]
+    if (!gtmDataLayer) return
+    gtmDataLayer.push({ exp })
+  <% } else { %>
+    // Default: use Google Analytics integration
+    const { ga } = window
+    if (!ga) return
+    ga('set', 'exp', exp)
   <% } %>
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,14 +120,32 @@ function setCookie(ctx, name, value, maxAge = <%= options.maxAge %>) {
 }
 
 // https://developers.google.com/optimize/devguides/experiments
-function googleOptimize({ experiment }) {
-  if (process.server || !window.ga || !experiment || !experiment.experimentID) {
+function googleOptimize(ctx) {
+  const { experiment } = ctx
+  if (process.server || !experiment || !experiment.experimentID) {
     return
   }
 
-  const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
-
-  window.ga('set', 'exp', exp)
+  // Choose method to track experiment and variant
+  <% if (options.eventHandler === 'ga') { %>
+    // Use Google Analytics integration
+    // https://developers.google.com/optimize/devguides/experiments
+    const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
+    if (!window.ga) return
+    window.ga('set', 'exp', exp)
+  <% } else if (options.eventHandler === 'gtm') { %>
+    // Use @nuxtjs/gtm-module
+    if (!ctx.$gtm) return
+    ctx.$gtm.push({
+      exp: exp
+    })
+  <% } else if (options.eventHandler === 'dataLayer') { %>
+    // Use other tag manager integration
+    if (!window[options.dataLayer]) return
+    window[options.dataLayer].push({
+      exp: exp
+    })
+  <% } %>
 }
 
 // should we skip bots?

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,27 +120,12 @@ function setCookie(ctx, name, value, maxAge = <%= options.maxAge %>) {
 }
 
 // https://developers.google.com/optimize/devguides/experiments
-function googleOptimize({ experiment, $gtm }) {
+function googleOptimize(ctx) {
+  const { experiment } = ctx
   if (process.server || !experiment || !experiment.experimentID) return
 
-  const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
-
-  // Choose method to track experiment and variant
-  <% if (options.eventHandler === 'gtm') { %>
-    // Use @nuxtjs/gtm-module
-    if (!$gtm) return
-  $gtm.push({ exp })
-    <% } else if (options.eventHandler === 'dataLayer') { %>
-    // Use other tag manager integration
-    const gtmDataLayer = window[<%= options.dataLayer %>]
-    if (!gtmDataLayer) return
-    gtmDataLayer.push({ exp })
-  <% } else { %>
-    // Default: use Google Analytics integration
-    const { ga } = window
-    if (!ga) return
-    ga('set', 'exp', exp)
-  <% } %>
+  const handler = <%= serializeFunction(options.eventHandler) %>
+  handler(experiment, ctx)
 }
 
 // should we skip bots?


### PR DESCRIPTION
This PR is inspired from #13. That PR seems inactive so this will address the need for GTM integration.

Adds the possibility to use [@nuxtjs/gtm-module](https://github.com/nuxt-community/gtm-module) or custom tag manager implementation with the possibility to rename used dataLayer variable.

This PR adds three options to implement sending experiment info:
- "ga" (Default) – Use Google Analytics as before this PR.
- "gtm" – Use [@nuxtjs/gtm-module](https://github.com/nuxt-community/gtm-module) to push exp variable to Data Layer
- "dataLayer" – Use custom GTM integration to push exp variable to configurable Data Layer. Data Layer name can be configured with `options.dataLayer: DATA_LAYER_NAME`
