### PR TITLE
use injected `$ga` instead of `window.ga`

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,14 +120,18 @@ function setCookie(ctx, name, value, maxAge = <%= options.maxAge %>) {
 }
 
 // https://developers.google.com/optimize/devguides/experiments
-function googleOptimize({ experiment }) {
-  if (process.server || !window.ga || !experiment || !experiment.experimentID) {
+function googleOptimize({ experiment, $ga }) {
+  if (process.server || (!window.ga && !$ga) || !experiment || !experiment.experimentID) {
     return
   }
 
   const exp = experiment.experimentID + '.' + experiment.$variantIndexes.join('-')
 
-  window.ga('set', 'exp', exp)
+  if ($ga) {
+    $ga.set('exp', exp)
+  } else if (window.ga) {
+    window.ga('set', 'exp', exp)
+  }
 }
 
 // should we skip bots?


### PR DESCRIPTION
Use the injected `ctx.$ga` handler from `@nuxtjs/google-analytics` instead of `window.ga` package if it is available.

I myself had some difficulties with the new version of `@nuxtjs/google-analytics` package which `window.ga` was not available in the `googleOptimize` function; but after using the injected `$ga` handler, it was working fine.